### PR TITLE
Add flexibility to metadata input, structure of output

### DIFF
--- a/files/exampleJob.json
+++ b/files/exampleJob.json
@@ -4,7 +4,7 @@
   "data_file": "projects/list_of_images.csv", 
   "input": "projects/input/",
   "output": "projects/output/",
-  "output_structure": "Metadata_Plate-Metadata_Well-Metadata_Site"
+  "output_structure": "Metadata_Plate-Metadata_Well-Metadata_Site",
   "_comment2": "The following groups are tasks, and each will be run in parallel",
   "groups": [
     {"Metadata": "Metadata_Plate=Plate1,Metadata_Well=A01,Metadata_Site=1"},

--- a/files/exampleJob.json
+++ b/files/exampleJob.json
@@ -4,6 +4,7 @@
   "data_file": "projects/list_of_images.csv", 
   "input": "projects/input/",
   "output": "projects/output/",
+  "output_structure": "Metadata_Plate-Metadata_Well-Metadata_Site"
   "_comment2": "The following groups are tasks, and each will be run in parallel",
   "groups": [
     {"Metadata": "Metadata_Plate=Plate1,Metadata_Well=A01,Metadata_Site=1"},

--- a/run.py
+++ b/run.py
@@ -160,11 +160,14 @@ def submitJob():
 
 	# Step 1: Read the job configuration file
 	jobInfo = loadConfig(sys.argv[2])
-	templateMessage = {'pipeline': jobInfo["pipeline"],
+	if 'output_structure' not in jobInfo.keys(): #backwards compatibility for 1.0.0
+		jobInfo["output_structure"]=''
+	templateMessage = {'Metadata': '',
+		'pipeline': jobInfo["pipeline"],
 		'output': jobInfo["output"],
             	'input': jobInfo["input"],
 		'data_file': jobInfo["data_file"],
-		'Metadata': ''
+		'output_structure':jobInfo["output_structure"]
 	}
 
 	# Step 2: Reach the queue and schedule tasks
@@ -172,7 +175,11 @@ def submitJob():
 	queue = JobQueue()
 	print 'Scheduling tasks'
 	for batch in jobInfo["groups"]:
-		templateMessage["Metadata"] = batch["Metadata"]
+		#support Metadata passed as either a single string or as a list
+		try: #single string ('canonical' DCP)
+			templateMessage["Metadata"] = batch["Metadata"]
+		except KeyError: #list of parameters (cellprofiler --print-groups)
+			templateMessage["Metadata"] = batch
 		queue.scheduleBatch(templateMessage)
 	print 'Job submitted. Check your queue'
 

--- a/worker/cp-worker.py
+++ b/worker/cp-worker.py
@@ -90,6 +90,7 @@ def runCellProfiler(message):
 		return 'INPUT_PROBLEM'
 	else:
 		metadataID = message['output_structure']
+		metadataForCall = ''
 		for eachMetadata in message['Metadata'].keys():
 			if eachMetadata not in metadataID:
 				watchtowerlogger=watchtower.CloudWatchLogHandler(log_group=LOG_GROUP_NAME, stream_name=str(message['Metadata'].values()),create_log_group=False)
@@ -99,6 +100,8 @@ def runCellProfiler(message):
 				return 'INPUT_PROBLEM'
 			else:
 				metadataID = string.replace(metadataID,eachMetadata,message['Metadata'][eachMetadata])
+				metadataForCall+=eachMetadata+'='+message['Metadata'][eachMetadata]+','
+		message['Metadata']=metadataForCall[:-1]
     elif message['output_structure']!='': #support for explicit output structuring
 	metadataID = message['output_structure']
 	for eachMetadata in message['Metadata'].split(','):

--- a/worker/cp-worker.py
+++ b/worker/cp-worker.py
@@ -74,6 +74,12 @@ def printandlog(text,logger):
 def runCellProfiler(message):
     #List the directories in the bucket- this prevents a strange s3fs error
     os.system('ls '+DATA_ROOT+r'/projects')
+    
+    # Configure the logs
+    logger = logging.getLogger(__name__)
+    watchtowerlogger=watchtower.CloudWatchLogHandler(log_group=LOG_GROUP_NAME, stream_name=metadataID,create_log_group=False)
+    logger.addHandler(watchtowerlogger)
+	
 	
     # Prepare paths and parameters
     if type(message['Metadata'])==dict: #support for cellprofiler --print-groups output
@@ -118,10 +124,7 @@ def runCellProfiler(message):
 			return 'SUCCESS'
 	except KeyError: #Returned if that folder does not exist
 		pass
-    # Configure the logs
-    logger = logging.getLogger(__name__)
-    watchtowerlogger=watchtower.CloudWatchLogHandler(log_group=LOG_GROUP_NAME, stream_name=metadataID,create_log_group=False)
-    logger.addHandler(watchtowerlogger)
+
     # Build and run CellProfiler command
     cpDone = localOut + '/cp.is.done'
     if message['pipeline'][-3:]!='.h5':

--- a/worker/cp-worker.py
+++ b/worker/cp-worker.py
@@ -77,13 +77,14 @@ def runCellProfiler(message):
     
     # Configure the logs
     logger = logging.getLogger(__name__)
-    watchtowerlogger=watchtower.CloudWatchLogHandler(log_group=LOG_GROUP_NAME, stream_name=metadataID,create_log_group=False)
-    logger.addHandler(watchtowerlogger)
+
 	
 	
     # Prepare paths and parameters
     if type(message['Metadata'])==dict: #support for cellprofiler --print-groups output
 	if  message['output_structure']=='':
+		watchtowerlogger=watchtower.CloudWatchLogHandler(log_group=LOG_GROUP_NAME, stream_name=str(message['Metadata'].values()),create_log_group=False)
+    		logger.addHandler(watchtowerlogger)
 		printandlog('You must specify an output structure when passing Metadata as dictionaries',logger)
 		logger.removeHandler(watchtowerlogger)
 		return 'INPUT_PROBLEM'
@@ -91,6 +92,8 @@ def runCellProfiler(message):
 		metadataID = message['output_structure']
 		for eachMetadata in message['Metadata'].keys():
 			if eachMetadata not in metadataID:
+				watchtowerlogger=watchtower.CloudWatchLogHandler(log_group=LOG_GROUP_NAME, stream_name=str(message['Metadata'].values()),create_log_group=False)
+    				logger.addHandler(watchtowerlogger)
 				printandlog('Your specified output structure does not match the Metadata passed',logger)
 				logger.removeHandler(watchtowerlogger)
 				return 'INPUT_PROBLEM'
@@ -100,6 +103,8 @@ def runCellProfiler(message):
 	metadataID = message['output_structure']
 	for eachMetadata in message['Metadata'].split(','):
 		if eachMetadata not in metadataID:
+			watchtowerlogger=watchtower.CloudWatchLogHandler(log_group=LOG_GROUP_NAME, stream_name=message['Metadata'],create_log_group=False)
+    			logger.addHandler(watchtowerlogger)
 			printandlog('Your specified output structure does not match the Metadata passed',logger)
 			logger.removeHandler(watchtowerlogger)
 			return 'INPUT_PROBLEM' 
@@ -107,6 +112,9 @@ def runCellProfiler(message):
 			metadataID = string.replace(metadataID,eachMetadata.split('=')[0],eachMetadata.split('=')[1])
     else: #backwards compatability with 1.0.0 and/or no desire to structure output
     	metadataID = '-'.join([x.split('=')[1] for x in message['Metadata'].split(',')]) # Strip equal signs from the metadata
+
+    watchtowerlogger=watchtower.CloudWatchLogHandler(log_group=LOG_GROUP_NAME, stream_name=metadataID,create_log_group=False)
+    logger.addHandler(watchtowerlogger)	
 	
     localOut = LOCAL_OUTPUT + '/%(MetadataID)s' % {'MetadataID': metadataID}
     remoteOut= os.path.join(message['output'],metadataID)

--- a/worker/cp-worker.py
+++ b/worker/cp-worker.py
@@ -102,7 +102,7 @@ def runCellProfiler(message):
     elif message['output_structure']!='': #support for explicit output structuring
 	metadataID = message['output_structure']
 	for eachMetadata in message['Metadata'].split(','):
-		if eachMetadata not in metadataID:
+		if eachMetadata.split('=')[0] not in metadataID:
 			watchtowerlogger=watchtower.CloudWatchLogHandler(log_group=LOG_GROUP_NAME, stream_name=message['Metadata'],create_log_group=False)
     			logger.addHandler(watchtowerlogger)
 			printandlog('Your specified output structure does not match the Metadata passed',logger)


### PR DESCRIPTION
Allows you to specify the output structure of your data- ie Metadata_Plate/Metadata_Well-Metadata_Site rather than coercing it to Metadata_Plate-Metadata_Well-Metadata_Site.  

Also allows you to pass the metadata as a dictionary (such as the ones created by cellprofiler --print-groups) rather than an ordered list.  This requires a specified output structure from above.

Will return sensible errors if strings/keys in metadata don't match the output structure specified (watch your spelling!).  Creation of the output structure is done with simple string replacement, so if for some reason you had Metadata with names where one is a subset of the other (like Metadata_Site and Metadata_S), make sure to pass the metadata as an ordered list and to put the longer piece of metadata first if you don't want bad things to happen.

Will resolve #51 and #52