### PR TITLE
Fix missing arguments in call to killdeadAlarms in Monitor

### DIFF
--- a/run.py
+++ b/run.py
@@ -798,7 +798,7 @@ def monitor(cheapest=False):
             cloud.delete_alarms(AlarmNames=del_alarms)
             time.sleep(10)
             instancelist = instancelist[100:]
-        killdeadAlarms(fleetId,monitorapp)
+        killdeadAlarms(fleetId,monitorapp,ec2,cloud)
     except:
         pass
 


### PR DESCRIPTION
This should fix alarms for spot instances not being deleted.