### PR TITLE
Pin s3fs

### DIFF
--- a/worker/Dockerfile
+++ b/worker/Dockerfile
@@ -31,6 +31,7 @@ RUN apt-get install --only-upgrade bash
 WORKDIR /usr/local/src
 RUN git clone https://github.com/s3fs-fuse/s3fs-fuse.git
 WORKDIR /usr/local/src/s3fs-fuse
+RUN git checkout 561ce1e
 RUN ./autogen.sh
 RUN ./configure
 RUN make


### PR DESCRIPTION
Newer versions of s3fs require FUSE3; we will need to figure out how to support that.